### PR TITLE
Add tests for file management scripts

### DIFF
--- a/tests/test_cleanup_orphans.py
+++ b/tests/test_cleanup_orphans.py
@@ -1,0 +1,31 @@
+import pandas as pd
+from unittest.mock import MagicMock
+import cleanup_orphans
+
+
+def test_find_rows_missing_google_ids(monkeypatch):
+    df = pd.DataFrame({'pdf_id': ['1', '2'], 'google_id': ['a', 'b']})
+
+    monkeypatch.setattr(cleanup_orphans, 'config', {'LIBRARY_UNIFIED': 'lib'})
+    monkeypatch.setattr(cleanup_orphans, 'fetch_sheet', lambda sc, sid: MagicMock())
+
+    def fake_flag(sheet, full_df, orphan_rows):
+        assert list(orphan_rows['pdf_id']) == ['2']
+        return [{'action': 'flag', 'pdf_id': 'b'}]
+
+    monkeypatch.setattr(cleanup_orphans, 'flag_rows_as_orphans', fake_flag)
+
+    orphans, logs = cleanup_orphans.find_rows_missing_google_ids(MagicMock(), df, {'a'})
+
+    assert list(orphans['pdf_id']) == ['2']
+    assert logs == [{'action': 'flag', 'pdf_id': 'b'}]
+
+
+def test_find_files_missing_rows(monkeypatch):
+    lib_df = pd.DataFrame({'google_id': ['a']})
+    files_df = pd.DataFrame({'ID': ['a', 'b'], 'Name': ['one.pdf', 'two.pdf'], 'folder': ['PDF_TAGGING', 'PDF_TAGGING']})
+
+    orphans, logs = cleanup_orphans.find_files_missing_rows(lib_df, files_df)
+
+    assert list(orphans['ID']) == ['b']
+    assert logs == [{'action': 'orphan_file_detected_in_PDF_TAGGING', 'pdf_id': 'b', 'pdf_file_name': 'two.pdf'}]

--- a/tests/test_promote_files.py
+++ b/tests/test_promote_files.py
@@ -1,0 +1,39 @@
+import pandas as pd
+from unittest.mock import MagicMock
+import promote_files
+
+
+def test_upsert_single_file_rejected(monkeypatch):
+    monkeypatch.setattr(promote_files, 'config', {'PDF_LIVE': 'live', 'LIBRARY_UNIFIED': 'lib'})
+
+    row = pd.Series({'pdf_id': '1', 'pdf_file_name': 'f.pdf', 'google_id': 'gid', 'status': 'new_tagged'})
+
+    monkeypatch.setattr(promote_files, 'in_qdrant', lambda client, col, pid: True)
+
+    result, pid = promote_files.upsert_single_file(MagicMock(), MagicMock(), MagicMock(), row, 0)
+
+    assert result == 'rejected'
+    assert pid == '1'
+
+
+def test_upsert_single_file_success(monkeypatch):
+    monkeypatch.setattr(promote_files, 'config', {'PDF_LIVE': 'live', 'LIBRARY_UNIFIED': 'lib'})
+    row = pd.Series({'pdf_id': '2', 'pdf_file_name': 'g.pdf', 'google_id': 'gid', 'status': 'new_tagged'})
+
+    monkeypatch.setattr(promote_files, 'in_qdrant', lambda *a, **k: False)
+    monkeypatch.setattr(promote_files, 'pdf_to_Docs_via_Drive', lambda *a, **k: ['doc'])
+    monkeypatch.setattr(promote_files, 'chunk_Docs', lambda docs, conf: ['chunk'])
+    vec = MagicMock()
+    monkeypatch.setattr(promote_files, 'init_vectorstore', lambda client: vec)
+    monkeypatch.setattr(promote_files, 'move_pdf', lambda *a, **k: None)
+
+    sheet_mock = MagicMock()
+    monkeypatch.setattr(promote_files, 'fetch_sheet', lambda sc, sid: sheet_mock)
+    monkeypatch.setattr(promote_files, 'log_event', lambda *a, **k: None)
+
+    result, pid = promote_files.upsert_single_file(MagicMock(), MagicMock(), MagicMock(), row, 1)
+
+    assert result == 'uploaded'
+    assert row['status'] == 'live'
+    assert sheet_mock.update.called
+    vec.add_documents.assert_called()

--- a/tests/test_propose_new_files.py
+++ b/tests/test_propose_new_files.py
@@ -1,0 +1,50 @@
+import io
+import pandas as pd
+from unittest.mock import MagicMock
+import propose_new_files
+
+
+def make_file(name: str) -> io.BytesIO:
+    buf = io.BytesIO(b'data')
+    buf.name = name
+    return buf
+
+
+def test_propose_new_files_handles_duplicates(monkeypatch):
+    # fake config
+    monkeypatch.setattr(propose_new_files, 'config', {'LIBRARY_UNIFIED': 'lib', 'PDF_TAGGING': 'tag'})
+
+    def fake_fetch_sheet_as_df(client, sheet_id):
+        return pd.DataFrame({'pdf_id': ['1']})
+
+    monkeypatch.setattr(propose_new_files, 'fetch_sheet_as_df', fake_fetch_sheet_as_df)
+    monkeypatch.setattr(propose_new_files, 'compute_pdf_id', lambda f: '1' if f.name == 'dup.pdf' else '2')
+    monkeypatch.setattr(propose_new_files, 'upload_pdf', lambda *args, **kwargs: 'gfile')
+
+    appended = []
+    monkeypatch.setattr(propose_new_files, 'append_new_rows', lambda sc, sid, df: appended.append(df))
+
+    events = []
+    monkeypatch.setattr(propose_new_files, 'log_event', lambda *args, **kwargs: events.append(args[1]))
+
+    dup = make_file('dup.pdf')
+    new = make_file('new.pdf')
+    new_rows, failed, duplicates = propose_new_files.propose_new_files(MagicMock(), MagicMock(), [dup, new])
+
+    assert duplicates == ['dup.pdf']
+    assert failed == []
+    assert list(new_rows['pdf_file_name']) == ['new.pdf']
+    assert 'duplicate_skipped' in events and 'new_pdf_to_PDF_TAGGING' in events
+
+
+def test_propose_new_files_handles_failures(monkeypatch):
+    monkeypatch.setattr(propose_new_files, 'config', {'LIBRARY_UNIFIED': 'lib', 'PDF_TAGGING': 'tag'})
+    monkeypatch.setattr(propose_new_files, 'fetch_sheet_as_df', lambda *a, **kw: pd.DataFrame({'pdf_id': []}))
+    monkeypatch.setattr(propose_new_files, 'compute_pdf_id', lambda f: None)
+
+    file1 = make_file('bad.pdf')
+    new_rows, failed, duplicates = propose_new_files.propose_new_files(MagicMock(), MagicMock(), [file1])
+
+    assert new_rows.empty
+    assert failed == ['bad.pdf']
+    assert duplicates == []


### PR DESCRIPTION
## Summary
- add tests for `propose_new_files` duplicate detection and failure handling
- test `upsert_single_file` status updates and rejection logic
- add orphan detection tests for cleanup helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a2f50aad8832f8fc6d33b0b463dea