### PR TITLE
Handle empty Google Sheets

### DIFF
--- a/gcp_utils.py
+++ b/gcp_utils.py
@@ -160,6 +160,13 @@ def fetch_sheet(sheets_client: SheetsClient, spreadsheet_id: str) -> Worksheet |
     try:
         sheet = sheets_client.open_by_key(spreadsheet_id).sheet1
         logging.info(sheet.title)
+        try:
+            if not sheet.get_all_values():
+                logging.error("Worksheet %s is empty.", spreadsheet_id)
+                return None
+        except Exception as inner:
+            logging.error("[fetch_sheet] Could not read worksheet %s values: %s", spreadsheet_id, inner)
+            return None
         return sheet
     except Exception as e:
         logging.error("[fetch_sheet] Failed to fetch worksheet: %s", e)
@@ -181,7 +188,6 @@ def fetch_sheet_as_df(sheets_client: SheetsClient, spreadsheet_id: str) -> pd.Da
     try:
         sheet = fetch_sheet(sheets_client, spreadsheet_id)
         if sheet is None:
-            logging.error("Worksheet %s is empty.", spreadsheet_id)
             return pd.DataFrame()
 
         df: pd.DataFrame = get_as_dataframe(sheet, evaluate_formulas=True, dtype=str)

--- a/tests/test_gcp_utils.py
+++ b/tests/test_gcp_utils.py
@@ -53,3 +53,14 @@ def test_fetch_sheet_as_df(monkeypatch, mock_sheets_client):
     monkeypatch.setattr(gcp_utils, 'get_as_dataframe', lambda sheet, evaluate_formulas=True, dtype=str: sample_df)
     df = gcp_utils.fetch_sheet_as_df(mock_sheets_client, 'sheet')
     assert df.equals(sample_df)
+
+
+def test_fetch_sheet_empty(mock_sheets_client):
+    empty_sheet = MagicMock()
+    empty_sheet.title = 'Empty'
+    empty_sheet.get_all_values.return_value = []
+    mock_sheets_client.open_by_key.return_value.sheet1 = empty_sheet
+
+    result = gcp_utils.fetch_sheet(mock_sheets_client, 'sheet_id')
+    assert result is None
+


### PR DESCRIPTION
## Summary
- add check for empty worksheets in `fetch_sheet`
- skip extra log in `fetch_sheet_as_df`
- test `fetch_sheet` on empty sheet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684add7c6194832f8cf0bfc0065c89a1