### PR TITLE
Flag missing gcp_file_id in Qdrant records

### DIFF
--- a/qdrant_utils.py
+++ b/qdrant_utils.py
@@ -419,7 +419,9 @@ def get_gcp_file_ids_by_pdf_id(client: QdrantClient, collection_name: str, pdf_i
             if not isinstance(payload, dict):
                 continue
             meta = payload.get("metadata", {})
-            if not _validate_metadata(meta, require_file_id=True):
+            # Include records even when gcp_file_id is missing so that
+            # build_status_map can flag them appropriately.
+            if not _validate_metadata(meta, require_file_id=False):
                 continue
             pid = meta.get("pdf_id")
             fid = meta.get("gcp_file_id") or meta.get("file_id")

--- a/status_map.py
+++ b/status_map.py
@@ -82,6 +82,10 @@ def build_status_map(drive_client, sheets_client, qdrant_client) -> pd.DataFrame
 
     status_df["zero_record_count"] = status_df["in_qdrant"] & (status_df["record_count"] == 0)
 
+    # Flag rows where Qdrant records exist but have no associated gcp_file_id
+    status_df["missing_gcp_file_id"] = status_df["missing_gcp_file_id"] |\
+        (status_df["in_qdrant"] & (status_df["unique_file_count"].fillna(0) == 0))
+
     def file_ids_match(row) -> bool | None:
         if not row["in_qdrant"]:
             return None

--- a/tests/test_qdrant_utils.py
+++ b/tests/test_qdrant_utils.py
@@ -97,16 +97,20 @@ def test_get_gcp_file_ids_by_pdf_id(monkeypatch, mock_qdrant_client):
     rec2.payload = {"metadata": {"pdf_id": "p1", "gcp_file_id": "f2"}}
     rec3 = MagicMock()
     rec3.payload = {"metadata": {"pdf_id": "p2", "file_id": "z"}}
+    rec4 = MagicMock()
+    rec4.payload = {"metadata": {"pdf_id": "p3"}}
 
     def fake_scroll(**kwargs):
-        return [rec1, rec2, rec3], None
+        return [rec1, rec2, rec3, rec4], None
 
     monkeypatch.setattr(mock_qdrant_client, "scroll", fake_scroll)
 
-    df = qdrant_utils.get_gcp_file_ids_by_pdf_id(mock_qdrant_client, "col", ["p1", "p2"])
+    df = qdrant_utils.get_gcp_file_ids_by_pdf_id(mock_qdrant_client, "col", ["p1", "p2", "p3"])
     df = df.sort_values("pdf_id").reset_index(drop=True)
 
     assert df.loc[0, "pdf_id"] == "p1"
     assert df.loc[0, "gcp_file_ids"] == ["f1", "f2"]
     assert df.loc[1, "pdf_id"] == "p2"
     assert df.loc[1, "gcp_file_ids"] == ["z"]
+    assert df.loc[2, "pdf_id"] == "p3"
+    assert df.loc[2, "gcp_file_ids"] == []

--- a/tests/test_status_map.py
+++ b/tests/test_status_map.py
@@ -16,15 +16,15 @@ def test_build_status_map(monkeypatch):
         "URL": ["u1", "u3", "u4"],
     })
     qsum_df = pd.DataFrame({
-        "pdf_id": ["p1", "p3", "p_orphan"],
-        "file_name": ["one.pdf", "three.pdf", "orphan_q.pdf"],
-        "record_count": [2, 0, 1],
-        "page_count": [1, 1, 1],
+        "pdf_id": ["p1", "p2", "p3", "p_orphan"],
+        "file_name": ["one.pdf", "two.pdf", "three.pdf", "orphan_q.pdf"],
+        "record_count": [2, 1, 0, 1],
+        "page_count": [1, 1, 1, 1],
     })
     qfile_df = pd.DataFrame({
-        "pdf_id": ["p1", "p3", "p_orphan"],
-        "gcp_file_ids": [["f1"], ["f_mismatch"], ["f_orphan_q"]],
-        "unique_file_count": [1, 1, 1],
+        "pdf_id": ["p1", "p2", "p3", "p_orphan"],
+        "gcp_file_ids": [["f1"], [], ["f_mismatch"], ["f_orphan_q"]],
+        "unique_file_count": [1, 0, 1, 1],
     })
 
     monkeypatch.setattr(status_map, "config", {"LIBRARY_UNIFIED": "lib", "PDF_LIVE": "live"})


### PR DESCRIPTION
## Summary
- handle Qdrant records without `gcp_file_id`
- include `p2` examples in status map tests
- expand Qdrant file id tests

## Testing
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d99fe80f8832f8e7d84468628851b